### PR TITLE
Remove last break in default statement

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,6 @@ function ObjectCompare(a, b) {
           break;
         default:
           return false;
-          break;
       }
     }
   }


### PR DESCRIPTION
The last `break;` has been removed as the code is never reached.